### PR TITLE
Fixed the behavior of backspace key when using search_key=None

### DIFF
--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -1584,7 +1584,7 @@ class TerminalMenu:
                         self._search_key is None and next_key == DEFAULT_SEARCH_KEY
                     ):
                         self._search.search_text = ""
-                    elif self._search_key is None:
+                    elif self._search_key is None and next_key not in ("backspace",):
                         self._search.search_text = next_key
                 else:
                     assert self._search.search_text is not None


### PR DESCRIPTION
When search_key=None, if we press backspace as the first character, the word is entered literally ("backspace") as the search term.

If the search_key is None and backspace is pressed, do nothing. (Do not set the search_key to "backspace".)

Partially resolves https://github.com/IngoMeyer441/simple-term-menu/issues/41 (The issue with accented characters mentioned in the issue description is not handled.)